### PR TITLE
Add header to locale rewrite logic

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -6,10 +6,15 @@ import {NextRequest, NextResponse} from "next/server"
 
 const SUPPORTED_LOCALES = ["pt", "en", "es"]
 const DEFAULT_LOCALE = "pt"
+const MIDDLEWARE_HEADER = "X-From-Middleware"
 
 export function middleware(req: NextRequest) {
   const url = req.nextUrl
   const {pathname} = url
+
+  if (req.headers.get(MIDDLEWARE_HEADER)) {
+    return NextResponse.next()
+  }
 
   // If the pathname already includes a locale, do nothing
   if (SUPPORTED_LOCALES.some(lng => pathname.startsWith(`/${lng}`))) {
@@ -25,7 +30,10 @@ export function middleware(req: NextRequest) {
     : DEFAULT_LOCALE
 
   url.pathname = `/${locale}${pathname}`
-  return NextResponse.redirect(url)
+  url.locale = locale
+  const res = NextResponse.rewrite(url)
+  res.headers.set(MIDDLEWARE_HEADER, "1")
+  return res
 }
 
 export const config = {


### PR DESCRIPTION
## Summary
- ensure locale rewrite includes request header `X-From-Middleware`
- skip locale rewrite when the header is present

## Testing
- `npm run build` *(fails: Missing API key and fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6840bb6f79a8832ab2d44758b7a5a6f0